### PR TITLE
Made all tests timezone aware

### DIFF
--- a/loefsys/events/tests/test_models.py
+++ b/loefsys/events/tests/test_models.py
@@ -11,8 +11,8 @@ class EventTestCase(TestCase):
     def test_create(self):
         """Test that Event instance can be created."""
         event = G(Event,
-                  start="2022-01-01 00:00:00",
-                  end="2023-01-01 00:00:00")
+                  start="2022-01-01 00:00:00+00:00",
+                  end="2023-01-01 00:00:00+00:00")
         self.assertIsNotNone(event)
         self.assertIsNotNone(event.pk)
 
@@ -24,8 +24,8 @@ class EventOrganizerTestCase(TestCase):
         """Test that EventOrganizer instance can be created."""
         organizer = G(EventOrganizer,
                       event=G(Event,
-                              start="2022-01-01 00:00:00",
-                              end="2023-01-01 00:00:00"))
+                              start="2022-01-01 00:00:00+00:00",
+                              end="2023-01-01 00:00:00+00:00"))
         self.assertIsNotNone(organizer)
         self.assertIsNotNone(organizer.pk)
 
@@ -37,7 +37,7 @@ class EventRegistrationTestCase(TestCase):
         """Test that EventRegistration instance can be created."""
         registration = G(EventRegistration,
                          event=G(Event,
-                                 start="2022-01-01 00:00:00",
-                                 end="2023-01-01 00:00:00"))
+                                 start="2022-01-01 00:00:00+00:00",
+                                 end="2023-01-01 00:00:00+00:00"))
         self.assertIsNotNone(registration)
         self.assertIsNotNone(registration.pk)

--- a/loefsys/reservations/tests/test_models.py
+++ b/loefsys/reservations/tests/test_models.py
@@ -88,8 +88,8 @@ class ReservationTestCase(TestCase):
         reservation = Reservation(
             reserved_item=self.reservable_item,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=12, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=13, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=13, minute=0, tzinfo=datetime.UTC),
         )
         reservation.save()
         self.assertIsNotNone(reservation)
@@ -101,8 +101,8 @@ class ReservationTestCase(TestCase):
             reservation = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=12, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation.save()
 
@@ -112,8 +112,8 @@ class ReservationTestCase(TestCase):
             reservation = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=13, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=13, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation.save()
 
@@ -122,16 +122,16 @@ class ReservationTestCase(TestCase):
         reservation1 = Reservation(
             reserved_item=self.reservable_item,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
         )
         reservation1.save()
 
         reservation2 = Reservation(
             reserved_item=self.reservable_item,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=13, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=14, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=13, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=14, minute=0, tzinfo=datetime.UTC),
         )
         reservation2.save()
 
@@ -144,8 +144,8 @@ class ReservationTestCase(TestCase):
             reservation1 = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation1.save()
             reservation1.clean()
@@ -153,8 +153,8 @@ class ReservationTestCase(TestCase):
             reservation2 = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=11, minute=30),
-                end=datetime.datetime(2025, 1, 1, hour=13, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=11, minute=30, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=13, minute=0, tzinfo=datetime.UTC),
             )
             reservation2.save()
             reservation2.clean()
@@ -165,16 +165,16 @@ class ReservationTestCase(TestCase):
             reservation1 = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation1.save()
 
             reservation2 = Reservation(
                 reserved_item=self.reservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation2.clean()
             reservation2.save()
@@ -193,16 +193,16 @@ class ReservationTestCase(TestCase):
         reservation1 = Reservation(
             reserved_item=self.reservable_item,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
         )
         reservation1.save()
 
         reservation2 = Reservation(
             reserved_item=reservable_item2,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=30),
-            end=datetime.datetime(2025, 1, 1, hour=13, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=30, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=13, minute=0, tzinfo=datetime.UTC),
         )
         reservation2.clean()
         reservation2.save()
@@ -215,8 +215,8 @@ class ReservationTestCase(TestCase):
         reservation = Reservation(
             reserved_item=self.reservable_item,
             reservee_user=self.reservee_user,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
         )
         reservation.save()
 
@@ -228,7 +228,7 @@ class ReservationTestCase(TestCase):
             reservation = Reservation(
                 reserved_item=self.unreservable_item,
                 reservee_user=self.reservee_user,
-                start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-                end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+                start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+                end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             )
             reservation.save()

--- a/loefsys/users/tests/test_models.py
+++ b/loefsys/users/tests/test_models.py
@@ -296,8 +296,8 @@ class ReservationUserSkippershipTestCase(TestCase):
             Reservation,
             reserved_item=self.boat,
             reservee_user=self.user1,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             authorized_userskippership=None,
         )
         with self.assertRaises(ValidationError):
@@ -312,8 +312,8 @@ class ReservationUserSkippershipTestCase(TestCase):
             Reservation,
             reserved_item=self.boat,
             reservee_user=self.user1,
-            start=datetime.datetime(2025, 1, 1, hour=11, minute=0),
-            end=datetime.datetime(2025, 1, 1, hour=12, minute=0),
+            start=datetime.datetime(2025, 1, 1, hour=11, minute=0, tzinfo=datetime.UTC),
+            end=datetime.datetime(2025, 1, 1, hour=12, minute=0, tzinfo=datetime.UTC),
             authorized_userskippership=userskippership,
         )
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
All tests that previously had a fixed time but no timezone have now been set to use UTC.

UTC was chosen for consistency, as using a local timezone forces you to either make the tests inconsistent during the year or fix to winter/summertime.