### PR TITLE
Fix documentation

### DIFF
--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       DJANGO_SECRET_KEY: django-insecure-loefbijter
       DJANGO_DATABASE_URL: sqlite:///db.sqlite
+      DJANGO_DEBUG: true
 
     steps:
       - name: Checkout the repo

--- a/.github/workflows/pages-sphinx.yml
+++ b/.github/workflows/pages-sphinx.yml
@@ -13,6 +13,7 @@ jobs:
       DJANGO_SECRET_KEY: django-insecure-loefbijter
       DJANGO_DATABASE_URL: sqlite:///db.sqlite
       SPHINX_APIDOCS_OPTIONS: members,show-inheritance
+      DJANGO_DEBUG: true
     permissions:
       contents: write
 


### PR DESCRIPTION
Fixes #91 by adding the DJANGO_DEBUG environment variable into both the docs and test CI. This also means that tests should now fail due to failing the tests, and not because the CI is broken, as has been the case since #84.